### PR TITLE
Fixed issue with Anchor declaration

### DIFF
--- a/ClassicCalendar.xml
+++ b/ClassicCalendar.xml
@@ -936,8 +936,8 @@
 							<KeyValue key="hideBackground" value="true" type="boolean"/>
 						</KeyValues>
 						<Anchors>
-							<Anchor point="TOPRIGHT" parentKey="$parent.ScrollingEditBox" relativePoint="TOPRIGHT" x="-2" y="-1"/>
-							<Anchor point="BOTTOMRIGHT" parentKey="$parent.ScrollingEditBox" relativePoint="BOTTOMRIGHT"/>
+							<Anchor point="TOPRIGHT" relativeKey="$parent.ScrollingEditBox" relativePoint="TOPRIGHT" x="-2" y="-1"/>
+							<Anchor point="BOTTOMRIGHT" relativeKey="$parent.ScrollingEditBox" relativePoint="BOTTOMRIGHT"/>
 						</Anchors>
 					</EventFrame>
 				</Frames>


### PR DESCRIPTION
Changed  parentKey to relativeKey within Anchors declared on line 939 & 940 of ClassicCalendar.xml.

Now allows the addon to load without error as of 1.15.5. 